### PR TITLE
[Design] #78 프로필 닉네임 설정화면 하단 MBTI 레이아웃 추가 구현

### DIFF
--- a/Catsby/FirstProfileSetting/Cell/MBTICollectionViewCell.swift
+++ b/Catsby/FirstProfileSetting/Cell/MBTICollectionViewCell.swift
@@ -1,0 +1,24 @@
+//
+//  MBTICollectionViewCell.swift
+//  Catsby
+//
+//  Created by Lee Wonsun on 2/9/25.
+//
+
+import UIKit
+
+final class MBTICollectionViewCell: UICollectionViewCell {
+    
+    static let id = "MBTICollectionViewCell"
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        backgroundColor = .catsMain
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/Catsby/FirstProfileSetting/Cell/MBTICollectionViewCell.swift
+++ b/Catsby/FirstProfileSetting/Cell/MBTICollectionViewCell.swift
@@ -6,15 +6,50 @@
 //
 
 import UIKit
+import SnapKit
 
-final class MBTICollectionViewCell: UICollectionViewCell {
+final class MBTICollectionViewCell: UICollectionViewCell, BaseConfigure {
     
     static let id = "MBTICollectionViewCell"
     
+    let topButton: BaseButton
+    let bottomButton: BaseButton
+    
     override init(frame: CGRect) {
+        topButton = BaseButton(title: "E", size: 20, weight: .regular, bgColor: .catsBlack, foreColor: .catsDarkgray)
+         
+        bottomButton = BaseButton(title: "I", size: 20, weight: .regular, bgColor: .catsBlack, foreColor: .catsDarkgray)
+        
         super.init(frame: frame)
         
-        backgroundColor = .catsMain
+//        backgroundColor = .catsMain
+        
+        [topButton, bottomButton].forEach {
+            $0.cornerRadius(self.frame.width / 2)
+            $0.stroke(.catsDarkgray, 1)
+        }
+        
+        configHierarchy()
+        configLayout()
+    }
+    
+    func configHierarchy() {
+        self.addSubview(topButton)
+        self.addSubview(bottomButton)
+    }
+    
+    func configLayout() {
+        topButton.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview()
+            $0.size.equalTo(self.frame.width)
+        }
+        
+        bottomButton.snp.makeConstraints {
+            $0.top.equalTo(topButton.snp.bottom).offset(12)
+            $0.horizontalEdges.equalToSuperview()
+            $0.size.equalTo(self.frame.width)
+        }
     }
     
     @available(*, unavailable)

--- a/Catsby/FirstProfileSetting/View/ProfileNicknameView.swift
+++ b/Catsby/FirstProfileSetting/View/ProfileNicknameView.swift
@@ -27,6 +27,22 @@ final class ProfileNicknameView: BaseView {
     private let underline = UIView()
     let checkNickname: BaseLabel
     let completeButton: BaseButton
+    private let mbtiTitleLabel: BaseLabel
+    let mbtiCollectionView: UICollectionView
+    
+    private func collectionviewFlowLayout() -> UICollectionViewFlowLayout {
+        let cellSpacing: CGFloat = 12
+        let cellSize: CGFloat = 40
+        
+        let layout = UICollectionViewFlowLayout()
+        layout.scrollDirection = .horizontal
+        layout.minimumLineSpacing = cellSpacing
+        layout.minimumInteritemSpacing = cellSpacing
+        layout.itemSize = CGSize(width: cellSize, height: cellSize)
+        layout.sectionInset = .zero
+        
+        return layout
+    }
     
     
     override init(frame: CGRect) {
@@ -42,7 +58,13 @@ final class ProfileNicknameView: BaseView {
         completeButton.capsuleStyle()
         completeButton.stroke(.catsMain, 2)
         
+        mbtiTitleLabel = BaseLabel(text: "MBTI", align: .left, color: .catsBlack, size: 20, weight: .bold)
+        
+        mbtiCollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
+        
         super.init(frame: frame)
+        
+        mbtiCollectionView.collectionViewLayout = collectionviewFlowLayout()
         
         backgroundColor = .catsBlack
         configHierarchy()
@@ -59,7 +81,7 @@ final class ProfileNicknameView: BaseView {
     }
     
     override func configHierarchy() {
-        [profileImageView, cameraImageView, textfield, underline, checkNickname, completeButton].forEach {
+        [profileImageView, cameraImageView, textfield, underline, checkNickname, mbtiTitleLabel, mbtiCollectionView, completeButton].forEach {
             self.addSubview($0)
         }
     }
@@ -95,6 +117,18 @@ final class ProfileNicknameView: BaseView {
             $0.leading.equalTo(textfield.snp.leading)
         }
         
+        mbtiTitleLabel.snp.makeConstraints {
+            $0.top.equalTo(checkNickname.snp.bottom).offset(35)
+            $0.leading.equalTo(self.safeAreaLayoutGuide).inset(8)
+        }
+        
+        mbtiCollectionView.snp.makeConstraints {
+            $0.top.equalTo(mbtiTitleLabel.snp.top)
+            $0.trailing.equalTo(self.safeAreaLayoutGuide).inset(8)
+            $0.height.equalTo(92)
+            $0.width.equalTo(196)
+        }
+        
         completeButton.snp.makeConstraints {
             $0.bottom.equalTo(self.safeAreaLayoutGuide).inset(25)
             $0.horizontalEdges.equalTo(self.safeAreaLayoutGuide).inset(8)
@@ -111,5 +145,7 @@ final class ProfileNicknameView: BaseView {
         textfield.clearButtonMode = .whileEditing
         
         underline.backgroundColor = .catsWhite
+        
+        mbtiCollectionView.register(MBTICollectionViewCell.self, forCellWithReuseIdentifier: MBTICollectionViewCell.id)
     }
 }

--- a/Catsby/FirstProfileSetting/View/ProfileNicknameView.swift
+++ b/Catsby/FirstProfileSetting/View/ProfileNicknameView.swift
@@ -96,7 +96,7 @@ final class ProfileNicknameView: BaseView {
         }
         
         completeButton.snp.makeConstraints {
-            $0.top.equalTo(checkNickname.snp.bottom).offset(32)
+            $0.bottom.equalTo(self.safeAreaLayoutGuide).inset(25)
             $0.horizontalEdges.equalTo(self.safeAreaLayoutGuide).inset(8)
             $0.height.equalTo(44)
         }

--- a/Catsby/FirstProfileSetting/View/ProfileNicknameView.swift
+++ b/Catsby/FirstProfileSetting/View/ProfileNicknameView.swift
@@ -32,7 +32,7 @@ final class ProfileNicknameView: BaseView {
     
     private func collectionviewFlowLayout() -> UICollectionViewFlowLayout {
         let cellSpacing: CGFloat = 12
-        let cellSize: CGFloat = 40
+        let cellSize: CGFloat = 50
         
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .horizontal
@@ -58,7 +58,7 @@ final class ProfileNicknameView: BaseView {
         completeButton.capsuleStyle()
         completeButton.stroke(.catsMain, 2)
         
-        mbtiTitleLabel = BaseLabel(text: "MBTI", align: .left, color: .catsBlack, size: 20, weight: .bold)
+        mbtiTitleLabel = BaseLabel(text: "MBTI", align: .left, size: 20, weight: .bold)
         
         mbtiCollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
         
@@ -125,8 +125,8 @@ final class ProfileNicknameView: BaseView {
         mbtiCollectionView.snp.makeConstraints {
             $0.top.equalTo(mbtiTitleLabel.snp.top)
             $0.trailing.equalTo(self.safeAreaLayoutGuide).inset(8)
-            $0.height.equalTo(92)
-            $0.width.equalTo(196)
+            $0.height.equalTo(112)
+            $0.width.equalTo(236)
         }
         
         completeButton.snp.makeConstraints {

--- a/Catsby/FirstProfileSetting/View/ProfileNicknameView.swift
+++ b/Catsby/FirstProfileSetting/View/ProfileNicknameView.swift
@@ -32,7 +32,7 @@ final class ProfileNicknameView: BaseView {
     
     private func collectionviewFlowLayout() -> UICollectionViewFlowLayout {
         let cellSpacing: CGFloat = 12
-        let cellSize: CGFloat = 50
+        let cellSize: CGFloat = (mbtiCollectionView.bounds.width - (cellSpacing * 3)) / 4
         
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .horizontal
@@ -64,8 +64,6 @@ final class ProfileNicknameView: BaseView {
         
         super.init(frame: frame)
         
-        mbtiCollectionView.collectionViewLayout = collectionviewFlowLayout()
-        
         backgroundColor = .catsBlack
         configHierarchy()
         configLayout()
@@ -78,6 +76,13 @@ final class ProfileNicknameView: BaseView {
         let profileRadius = profileImageView.frame.width / 2
         profileImageView.clipCorner(profileRadius)
         profileImageView.stroke(.catsMain, 2)
+        
+        mbtiCollectionView.snp.makeConstraints {
+            let cellHeight = ((mbtiCollectionView.bounds.width - 36) / 4) * 2 + 12
+            $0.height.equalTo(cellHeight)
+        }
+        
+        mbtiCollectionView.collectionViewLayout = collectionviewFlowLayout()
     }
     
     override func configHierarchy() {
@@ -123,10 +128,9 @@ final class ProfileNicknameView: BaseView {
         }
         
         mbtiCollectionView.snp.makeConstraints {
-            $0.top.equalTo(mbtiTitleLabel.snp.top)
+            $0.top.equalTo(mbtiTitleLabel.snp.top).offset(4)
             $0.trailing.equalTo(self.safeAreaLayoutGuide).inset(8)
-            $0.height.equalTo(112)
-            $0.width.equalTo(236)
+            $0.leading.equalTo(mbtiTitleLabel.snp.trailing).offset(60)
         }
         
         completeButton.snp.makeConstraints {

--- a/Catsby/FirstProfileSetting/View/ProfileNicknameView.swift
+++ b/Catsby/FirstProfileSetting/View/ProfileNicknameView.swift
@@ -32,13 +32,14 @@ final class ProfileNicknameView: BaseView {
     
     private func collectionviewFlowLayout() -> UICollectionViewFlowLayout {
         let cellSpacing: CGFloat = 12
-        let cellSize: CGFloat = (mbtiCollectionView.bounds.width - (cellSpacing * 3)) / 4
+        let cellWidth: CGFloat = (mbtiCollectionView.bounds.width - (cellSpacing * 3)) / 4
+        let cellHeight: CGFloat = mbtiCollectionView.bounds.height
         
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .horizontal
         layout.minimumLineSpacing = cellSpacing
-        layout.minimumInteritemSpacing = cellSpacing
-        layout.itemSize = CGSize(width: cellSize, height: cellSize)
+        layout.minimumInteritemSpacing = 0
+        layout.itemSize = CGSize(width: cellWidth, height: cellHeight)
         layout.sectionInset = .zero
         
         return layout
@@ -149,6 +150,8 @@ final class ProfileNicknameView: BaseView {
         textfield.clearButtonMode = .whileEditing
         
         underline.backgroundColor = .catsWhite
+        
+        mbtiCollectionView.backgroundColor = .clear
         
         mbtiCollectionView.register(MBTICollectionViewCell.self, forCellWithReuseIdentifier: MBTICollectionViewCell.id)
     }

--- a/Catsby/FirstProfileSetting/ViewController/ProfileNicknameViewController.swift
+++ b/Catsby/FirstProfileSetting/ViewController/ProfileNicknameViewController.swift
@@ -31,6 +31,7 @@ final class ProfileNicknameViewController: UIViewController {
         
         setNavigation()
         tapGesture()
+        setCollectionView()
         bindVMData()
         
         mainView.completeButton.addTarget(self, action: #selector(completeButtonTapped), for: .touchUpInside)
@@ -78,6 +79,26 @@ extension ProfileNicknameViewController: UITextFieldDelegate {
     
     @objc func checkNicknameCondition(textfield: UITextField) {
         viewModel.inputNickname.value = textfield.text
+    }
+}
+
+extension ProfileNicknameViewController: UICollectionViewDelegate, UICollectionViewDataSource {
+
+    private func setCollectionView() {
+        mainView.mbtiCollectionView.delegate = self
+        mainView.mbtiCollectionView.dataSource = self
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return 4
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MBTICollectionViewCell.id, for: indexPath) as? MBTICollectionViewCell else { return UICollectionViewCell() }
+        
+        
+        return cell
     }
 }
 


### PR DESCRIPTION
## 한 일
1. 기존 완료 버튼 위치 화면 하단으로 이동
2. 완료버튼의 기존 자리에 MBTI 레이아웃 추가
- 레이아웃의 width와 height는 다양한 기기에서 유동적으로 사이즈 조절되도록 조절

<img width="314" alt="image" src="https://github.com/user-attachments/assets/934ce667-6990-4b64-82df-3edb42c9f580" />
