### PR TITLE
[Feat] 닉네임 조건에 어긋날 시, 상태레이블 색상 red로 변경

### DIFF
--- a/Catsby/FirstProfileSetting/ViewController/ProfileNicknameViewController.swift
+++ b/Catsby/FirstProfileSetting/ViewController/ProfileNicknameViewController.swift
@@ -41,6 +41,10 @@ final class ProfileNicknameViewController: UIViewController {
         viewModel.outputInvalidText.bind { [weak self] _ in
             self?.mainView.checkNickname.text = self?.viewModel.outputInvalidText.value
         }
+        
+        viewModel.outputIsNicknameError.bind { [weak self] isError in
+            self?.mainView.checkNickname.textColor = isError ? .catsRed : .catsMain
+        }
     }
     
     private func tapGesture() {

--- a/Catsby/ViewModel/ProfileNicknameViewModel.swift
+++ b/Catsby/ViewModel/ProfileNicknameViewModel.swift
@@ -54,6 +54,7 @@ final class ProfileNicknameViewModel {
     let inputButtonAction: Observable<(Int, Int)> = Observable((0, 0))
     
     let outputInvalidText: Observable<String> = Observable("")
+    let outputIsNicknameError: Observable<Bool> = Observable(false)
     let outputViewTransition: Observable<Void> = Observable(())
     var outputIsTopOn: [Observable<Bool>] = []
     var outputIsBottomOn: [Observable<Bool>] = []
@@ -95,6 +96,7 @@ final class ProfileNicknameViewModel {
         for character in text {
             if "@#$%".contains(character) {
                 outputInvalidText.value = Comment.specialCharacter.rawValue
+                outputIsNicknameError.value = true
                 return
             }
         }
@@ -102,6 +104,7 @@ final class ProfileNicknameViewModel {
         // 숫자
         if text.contains(/\d/) {
             outputInvalidText.value = Comment.number.rawValue
+            outputIsNicknameError.value = true
             return
         }
         
@@ -110,10 +113,13 @@ final class ProfileNicknameViewModel {
         switch count {
         case 0:
             outputInvalidText.value = Comment.space.rawValue
+            outputIsNicknameError.value = false
         case 2...9:
             outputInvalidText.value = Comment.pass.rawValue
+            outputIsNicknameError.value = false
         default:
             outputInvalidText.value = Comment.length.rawValue
+            outputIsNicknameError.value = true
         }
     }
     


### PR DESCRIPTION
## 한 일
1. 조건에 어긋난 상태일 때 상태레이블 색상 변경
- 현재 ViewModel에 있던 단순한 오류 체크 로직에 색상 변경 감지할 수 있도록 Bool값의 output 프로퍼티 생성
- ViewController에서 불값에 따라 색상 달라지도록 컨트롤


![Simulator Screen Recording - iPhone 16 Pro - 2025-02-10 at 01 29 34](https://github.com/user-attachments/assets/7116abfc-38c7-4e5f-825f-146cab208fb3)