### PR TITLE
[Refactor] #95 메인화면 중 최근 검색어 ViewModel로 비즈니스 로직 분리

### DIFF
--- a/Catsby/FirstProfileSetting/ViewController/ProfileNicknameViewController.swift
+++ b/Catsby/FirstProfileSetting/ViewController/ProfileNicknameViewController.swift
@@ -37,6 +37,12 @@ final class ProfileNicknameViewController: UIViewController {
         mainView.completeButton.addTarget(self, action: #selector(completeButtonTapped), for: .touchUpInside)
     }
     
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesEnded(touches, with: event)
+        
+        view.endEditing(true)
+    }
+    
     private func bindVMData() {
         viewModel.output.invalidText.bind { [weak self] _ in
             self?.mainView.checkNickname.text = self?.viewModel.output.invalidText.value

--- a/Catsby/Manager/UserDefaultsManager.swift
+++ b/Catsby/Manager/UserDefaultsManager.swift
@@ -94,9 +94,15 @@ extension UserDefaultsManager {
         self.saveData(value: dicList, type: type)
     }
     
-    func resetData() {
+    func resetAllData() {
         for key in UserDefaults.standard.dictionaryRepresentation().keys {
             UserDefaults.standard.removeObject(forKey: key.description)
+        }
+    }
+    
+    func resetOneData(type: SaveData) {
+        for key in UserDefaults.standard.dictionaryRepresentation().keys {
+            UserDefaults.standard.removeObject(forKey: type.saveKey)
         }
     }
 }

--- a/Catsby/TabBarController/Setting/ViewController/SettingViewController.swift
+++ b/Catsby/TabBarController/Setting/ViewController/SettingViewController.swift
@@ -102,7 +102,7 @@ extension SettingViewController: UITableViewDelegate, UITableViewDataSource {
                 let nav = UINavigationController(rootViewController: OnboardingViewController())
                 self.viewTransition(style: .windowRoot, vc: nav)
                 
-                UserDefaultsManager.shared.resetData()
+                UserDefaultsManager.shared.resetAllData()
             }
         }
     }

--- a/Catsby/TabBarController/TodayMovie/Cell/RecentKeywordCollectionViewCell.swift
+++ b/Catsby/TabBarController/TodayMovie/Cell/RecentKeywordCollectionViewCell.swift
@@ -16,8 +16,6 @@ final class RecentKeywordCollectionViewCell: UICollectionViewCell, BaseConfigure
     private let stackView = UIStackView()
     private var keywordLabel: BaseLabel
     let deleteButton: BaseButton
-
-    var backgroundAction: (() -> ())?
     
     override init(frame: CGRect) {
         keywordLabel = BaseLabel(text: "", align: .right, color: .catsBlack, size: 14, weight: .medium)
@@ -32,15 +30,12 @@ final class RecentKeywordCollectionViewCell: UICollectionViewCell, BaseConfigure
 
         configHierarchy()
         configLayout()
-       
-//        backgroundTapGesture()
     }
     
     override func prepareForReuse() {
         super.prepareForReuse()
         
         keywordLabel.text = ""
-//        backgroundAction = {}
     }
     
     func configHierarchy() {
@@ -65,17 +60,6 @@ final class RecentKeywordCollectionViewCell: UICollectionViewCell, BaseConfigure
         stackView.alignment = .center
         
     }
-    
-//    private func backgroundTapGesture() {
-//        let tapgesture = UITapGestureRecognizer(target: self, action: #selector(backgroundTapped))
-//        bgView.isUserInteractionEnabled = true
-//        bgView.addGestureRecognizer(tapgesture)
-//    }
-
-//    @objc private func backgroundTapped() {
-//        print(#function)
-//        backgroundAction?()
-//    }
     
     func sendCellData(_ text: String) {
         keywordLabel.text = text

--- a/Catsby/TabBarController/TodayMovie/Cell/RecentKeywordCollectionViewCell.swift
+++ b/Catsby/TabBarController/TodayMovie/Cell/RecentKeywordCollectionViewCell.swift
@@ -15,9 +15,8 @@ final class RecentKeywordCollectionViewCell: UICollectionViewCell, BaseConfigure
     private let bgView = UIView()
     private let stackView = UIStackView()
     private var keywordLabel: BaseLabel
-    private let deleteButton: BaseButton
-    
-    var deleteAction: (() -> ())?
+    let deleteButton: BaseButton
+
     var backgroundAction: (() -> ())?
     
     override init(frame: CGRect) {
@@ -33,17 +32,15 @@ final class RecentKeywordCollectionViewCell: UICollectionViewCell, BaseConfigure
 
         configHierarchy()
         configLayout()
-        
-        deleteButton.addTarget(self, action: #selector(deleteButtonTapped), for: .touchUpInside)
-        backgroundTapGesture()
+       
+//        backgroundTapGesture()
     }
     
     override func prepareForReuse() {
         super.prepareForReuse()
         
         keywordLabel.text = ""
-        deleteAction = {}
-        backgroundAction = {}
+//        backgroundAction = {}
     }
     
     func configHierarchy() {
@@ -69,27 +66,28 @@ final class RecentKeywordCollectionViewCell: UICollectionViewCell, BaseConfigure
         
     }
     
-    private func backgroundTapGesture() {
-        let tapgesture = UITapGestureRecognizer(target: self, action: #selector(backgroundTapped))
-        bgView.isUserInteractionEnabled = true
-        bgView.addGestureRecognizer(tapgesture)
-    }
+//    private func backgroundTapGesture() {
+//        let tapgesture = UITapGestureRecognizer(target: self, action: #selector(backgroundTapped))
+//        bgView.isUserInteractionEnabled = true
+//        bgView.addGestureRecognizer(tapgesture)
+//    }
+
+//    @objc private func backgroundTapped() {
+//        print(#function)
+//        backgroundAction?()
+//    }
     
-    @objc private func deleteButtonTapped() {
-        deleteAction?()
-    }
-    
-    @objc private func backgroundTapped() {
-        backgroundAction?()
-    }
-    
-    func getDataFromAPI(_ text: String) {
+    func sendCellData(_ text: String) {
         keywordLabel.text = text
+        
+        cornerRadius()
     }
     
     func cornerRadius() {
         bgView.layer.cornerRadius = 15
         bgView.clipsToBounds = true
+        
+        self.layoutIfNeeded()
     }
     
     

--- a/Catsby/TabBarController/TodayMovie/Cell/TodayMovieCollectionViewCell.swift
+++ b/Catsby/TabBarController/TodayMovie/Cell/TodayMovieCollectionViewCell.swift
@@ -83,7 +83,7 @@ final class TodayMovieCollectionViewCell: UICollectionViewCell, BaseConfigure {
                                     options: [
                                         .processor(DownSampling.processor(posterImageView)),
                                         .scaleFactor(UIScreen.main.scale),
-                                        .onlyFromCache
+                                        .cacheOriginalImage
                                     ])
         
         titleLabel.text = title

--- a/Catsby/TabBarController/TodayMovie/ViewController/TodayMovieViewController.swift
+++ b/Catsby/TabBarController/TodayMovie/ViewController/TodayMovieViewController.swift
@@ -34,6 +34,7 @@ final class TodayMovieViewController: UIViewController {
         setCollectionView()
         todaymovieViewModel.input.getTodayMovieData.value = ()
         recentkeywordViewModel.input.checkKeyword.value = ()
+        recentkeywordViewModel.input.requestKeywordsList.value = ()
         bindVMData()
         tapGesture()
         
@@ -161,23 +162,15 @@ extension TodayMovieViewController: UICollectionViewDelegate, UICollectionViewDa
         switch collectionView {
         case mainView.recentKeywordCollectionView:
             
-            recentkeywordViewModel.input.requestKeywordsList.value = ()
-            
-            var keywordsList = recentkeywordViewModel.output.reversedKeywordsList.value
+            let keywordsList = recentkeywordViewModel.output.reversedKeywordsList.value
             let keyword = keywordsList[indexPath.item]
             
             guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: RecentKeywordCollectionViewCell.id, for: indexPath) as? RecentKeywordCollectionViewCell else { return UICollectionViewCell() }
+
+            cell.deleteButton.tag = indexPath.item
+            cell.deleteButton.addTarget(self, action: #selector(deleteButtonTapped), for: .touchUpInside)
             
-            cell.getDataFromAPI(keyword)
-            cell.deleteAction = {
-                // 해당되는 키워드 삭제
-                guard let index = keywordsList.firstIndex(of: keyword) else { return }
-                keywordsList.remove(at: index)
-                
-                UserDefaultsManager.shared.saveData(value: keywordsList, type: .recentKeyword)
-            }
-            cell.cornerRadius()
-            cell.layoutIfNeeded()
+            cell.sendCellData(keyword)
             
             return cell
             
@@ -204,7 +197,13 @@ extension TodayMovieViewController: UICollectionViewDelegate, UICollectionViewDa
     }
     
     @objc func heartButtonTapped(_ sender: UIButton) {
+        print(#function)
         todaymovieViewModel.input.heartBtnTapped.value = sender.tag
+    }
+    
+    @objc func deleteButtonTapped(_ sender: UIButton) {
+        print(#function)
+        recentkeywordViewModel.input.deleteBtnTapped.value = sender.tag
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {

--- a/Catsby/TabBarController/TodayMovie/ViewController/TodayMovieViewController.swift
+++ b/Catsby/TabBarController/TodayMovie/ViewController/TodayMovieViewController.swift
@@ -83,17 +83,15 @@ final class TodayMovieViewController: UIViewController {
     
     // 최근 검색어 전체 삭제 기능
     @objc func deleteAllkeywordsButtonTapped() {
-        let title = "최근검색어 삭제"
-        let message = "최근검색어를 모두 삭제하시겠습니까? 삭제 후에는 복구할 수 없습니다."
+        let title = recentkeywordViewModel.alertTitle
+        let message = recentkeywordViewModel.alertMessage
         
-        alerMessage(title, message) {
-            var searchKeywords = UserDefaultsManager.shared.getArrayData(type: .recentKeyword)
-            searchKeywords.removeAll()
-            UserDefaultsManager.shared.saveData(value: searchKeywords, type: .recentKeyword)
-            self.searchKeywordList = searchKeywords
+        alerMessage(title, message) { [weak self] in
             
-            self.mainView.noSearchLabel.isHidden = false
-            self.mainView.recentKeywordCollectionView.isHidden = true
+            self?.recentkeywordViewModel.input.alertAction.value = ()
+            
+            self?.mainView.noSearchLabel.isHidden = false
+            self?.mainView.recentKeywordCollectionView.isHidden = true
         }
     }
     

--- a/Catsby/ViewModel/RecentSearchKeywordViewModel.swift
+++ b/Catsby/ViewModel/RecentSearchKeywordViewModel.swift
@@ -1,0 +1,36 @@
+//
+//  RecentSearchKeywordViewModel.swift
+//  Catsby
+//
+//  Created by Lee Wonsun on 2/11/25.
+//
+
+import Foundation
+
+final class RecentSearchKeywordViewModel: BaseViewModel {
+    
+    struct Input {
+        
+    }
+    
+    struct Output {
+        
+        
+    }
+    
+    private(set) var input: Input
+    private(set) var output: Output
+    
+    init() {
+        
+        input = Input()
+        output = Output()
+        
+        transformBinds()
+    }
+    
+    func transformBinds() {
+        
+    }
+    
+}

--- a/Catsby/ViewModel/RecentSearchKeywordViewModel.swift
+++ b/Catsby/ViewModel/RecentSearchKeywordViewModel.swift
@@ -7,14 +7,25 @@
 
 import Foundation
 
+/*
+ < 분리되어야 할 로직 >
+ ✅ 1. 화면 분기점: viewdidLoad에서 트리거 받아서(✓ Input) bool값 내보내기(✓ output)
+    📌 기존에는 viewIsAppearing을 통해서 검색결과 내용을 반영시켰는데, 추후 검색결과 화면 VM 로직 짜면서 분리해줄 방법 찾기 (현재는 viewDidLoad에만... 매번 부르면 코스트가 많이 들 것 같음)
+ 2. 저장된 키워드 리스트를 시간순으로 보여주기 위해 역순으로 처리해서 내보내기(✓ output)
+    - output값 바인딩되면 datareload
+ 3. 전체 삭제 버튼 @objc 함수에서 트리거하기(✓ Input)
+    - 알럿 메시지의 action값을 input으로 해서... 처리해야하나..?
+ 4. 현재 cell 안에 있는 삭제 로직 VC으로 꺼내서 VM에서 처리(✓ Input) & (✓ output)
+ */
+
 final class RecentSearchKeywordViewModel: BaseViewModel {
     
     struct Input {
-        
+        let checkKeyword: Observable<Void> = Observable(())
     }
     
     struct Output {
-        
+        let isKeywordIn: Observable<Bool> = Observable(false)
         
     }
     
@@ -31,6 +42,21 @@ final class RecentSearchKeywordViewModel: BaseViewModel {
     
     func transformBinds() {
         
+        input.checkKeyword.bind { [weak self] _ in
+            self?.checkKeyword()
+        }
     }
     
+}
+
+// 매서드 분리
+extension RecentSearchKeywordViewModel {
+    
+    // 맨 처음 화면 진입 시, 최근검색어 갯수에 따라 화면 분기점 분리
+    private func checkKeyword() {
+        
+        let searchKeywordList = UserDefaultsManager.shared.getArrayData(type: .recentKeyword)
+        let keywordCount = searchKeywordList.count
+        output.isKeywordIn.value = (keywordCount == 0)
+    }
 }

--- a/Catsby/ViewModel/RecentSearchKeywordViewModel.swift
+++ b/Catsby/ViewModel/RecentSearchKeywordViewModel.swift
@@ -22,11 +22,13 @@ final class RecentSearchKeywordViewModel: BaseViewModel {
     
     struct Input {
         let checkKeyword: Observable<Void> = Observable(())
+        let alertAction: Observable<Void> = Observable(())
+        let requestKeywordsList: Observable<Void> = Observable(())
     }
     
     struct Output {
         let isKeywordIn: Observable<Bool> = Observable(false)
-        
+        let reversedKeywordsList: Observable<[String]> = Observable([])
     }
     
     private(set) var input: Input
@@ -45,6 +47,14 @@ final class RecentSearchKeywordViewModel: BaseViewModel {
         input.checkKeyword.bind { [weak self] _ in
             self?.checkKeyword()
         }
+        
+        input.alertAction.lazyBind { [weak self] _ in
+            self?.removeAllKeywords()
+        }
+        
+        input.requestKeywordsList.bind { [weak self] _ in
+            self?.getUserdefaultsKeywords()
+        }
     }
     
 }
@@ -58,5 +68,21 @@ extension RecentSearchKeywordViewModel {
         let searchKeywordList = UserDefaultsManager.shared.getArrayData(type: .recentKeyword)
         let keywordCount = searchKeywordList.count
         output.isKeywordIn.value = (keywordCount == 0)
+    }
+    
+    // 저장된 리스트 불러내서 collectionview CellForItemAt에 뿌리기
+    private func getUserdefaultsKeywords() {
+        
+        let reversedList = UserDefaultsManager.shared.getArrayData(type: .recentKeyword).reversed()
+        output.reversedKeywordsList.value = Array(reversedList)
+    }
+    
+    // 기존에 저장된 키워드 리스트 싹 삭제
+    private func removeAllKeywords() {
+        
+        UserDefaultsManager.shared.resetOneData(type: .recentKeyword)
+        
+        // 화면에 배열 불러내서 거기에 빈 것 넣어야할 것 같음
+       
     }
 }

--- a/Catsby/ViewModel/RecentSearchKeywordViewModel.swift
+++ b/Catsby/ViewModel/RecentSearchKeywordViewModel.swift
@@ -16,7 +16,7 @@ import Foundation
     📌 왠지 이것도 검색결과 화면이랑 엮여야 할 것 같은..?
  ✅ 3. 전체 삭제 버튼 @objc 함수에서 트리거하기(✓ Input)
     - 알럿 메시지의 action값을 input으로 해서... 처리해야하나..?
- 4. 현재 cell 안에 있는 삭제 로직 VC으로 꺼내서 VM에서 처리(✓ Input) & (✓ output)
+ ✅ 4. 현재 cell 안에 있는 삭제 로직 VC으로 꺼내서 VM에서 처리(✓ Input) & (✓ output)
  */
 
 final class RecentSearchKeywordViewModel: BaseViewModel {

--- a/Catsby/ViewModel/RecentSearchKeywordViewModel.swift
+++ b/Catsby/ViewModel/RecentSearchKeywordViewModel.swift
@@ -25,6 +25,7 @@ final class RecentSearchKeywordViewModel: BaseViewModel {
         let checkKeyword: Observable<Void> = Observable(())
         let alertAction: Observable<Void> = Observable(())
         let requestKeywordsList: Observable<Void> = Observable(())
+        let deleteBtnTapped: Observable<Int> = Observable(0)
     }
     
     struct Output {
@@ -59,8 +60,11 @@ final class RecentSearchKeywordViewModel: BaseViewModel {
         input.requestKeywordsList.bind { [weak self] _ in
             self?.getUserdefaultsKeywords()
         }
+        
+        input.deleteBtnTapped.lazyBind { [weak self] tag in
+            self?.deleteBtnTapped(tag)
+        }
     }
-    
 }
 
 // 매서드 분리
@@ -88,5 +92,28 @@ extension RecentSearchKeywordViewModel {
         
         // VC에서 사용중인 배열 비워주기
         output.reversedKeywordsList.value = []
+        
+        UserDefaultsManager.shared.saveData(value: [], type: .recentKeyword)
+    }
+    
+    // 최근검색어 x 표시 눌렀을 때 삭제
+    private func deleteBtnTapped(_ tag: Int) {
+        
+        var keywordsList = output.reversedKeywordsList.value
+        let keyword = keywordsList[tag]
+        
+        guard let index = keywordsList.firstIndex(of: keyword) else {
+            print("deleteButton fail")
+            return
+        }
+        
+        keywordsList.remove(at: index)
+        
+        output.reversedKeywordsList.value = keywordsList
+        
+        // 기존 배열 순서대로 다시 userdefaultsManager에 저장은 되어야 함
+        UserDefaultsManager.shared.saveData(value: Array(keywordsList.reversed()), type: .recentKeyword)
+        
+        output.isKeywordIn.value = (keywordsList.count == 0)
     }
 }

--- a/Catsby/ViewModel/RecentSearchKeywordViewModel.swift
+++ b/Catsby/ViewModel/RecentSearchKeywordViewModel.swift
@@ -11,9 +11,10 @@ import Foundation
  < 분리되어야 할 로직 >
  ✅ 1. 화면 분기점: viewdidLoad에서 트리거 받아서(✓ Input) bool값 내보내기(✓ output)
     📌 기존에는 viewIsAppearing을 통해서 검색결과 내용을 반영시켰는데, 추후 검색결과 화면 VM 로직 짜면서 분리해줄 방법 찾기 (현재는 viewDidLoad에만... 매번 부르면 코스트가 많이 들 것 같음)
- 2. 저장된 키워드 리스트를 시간순으로 보여주기 위해 역순으로 처리해서 내보내기(✓ output)
+ ✅ 2. 저장된 키워드 리스트를 시간순으로 보여주기 위해 역순으로 처리해서 내보내기(✓ output)
     - output값 바인딩되면 datareload
- 3. 전체 삭제 버튼 @objc 함수에서 트리거하기(✓ Input)
+    📌 왠지 이것도 검색결과 화면이랑 엮여야 할 것 같은..?
+ ✅ 3. 전체 삭제 버튼 @objc 함수에서 트리거하기(✓ Input)
     - 알럿 메시지의 action값을 input으로 해서... 처리해야하나..?
  4. 현재 cell 안에 있는 삭제 로직 VC으로 꺼내서 VM에서 처리(✓ Input) & (✓ output)
  */
@@ -33,6 +34,9 @@ final class RecentSearchKeywordViewModel: BaseViewModel {
     
     private(set) var input: Input
     private(set) var output: Output
+    
+    let alertTitle = "최근검색어 전체삭제"
+    let alertMessage = "최근검색어를 모두 삭제하시겠습니까? 삭제 후에는 복구할 수 없습니다."
     
     init() {
         
@@ -82,7 +86,7 @@ extension RecentSearchKeywordViewModel {
         
         UserDefaultsManager.shared.resetOneData(type: .recentKeyword)
         
-        // 화면에 배열 불러내서 거기에 빈 것 넣어야할 것 같음
-       
+        // VC에서 사용중인 배열 비워주기
+        output.reversedKeywordsList.value = []
     }
 }


### PR DESCRIPTION
## 한 일
1. 저장된 최근 검색어의 유무에 따라 첫 화면 분기점이 달라지는 로직 VM으로 이동
- VC의 viewDidLoad 시점에 트리거를 받아 검색어 갯수가 0인지 아닌지에 따라 각기 다른 화면 isHidden 처리

2. 저장된 키워드리스트를 검색순으로 보여주기 위한 로직 처리
- Userdefault에 저장된 배열을 .reversed() 시켜서 뷰컨에 전달

3. 전체 삭제버튼 cell에서 VC -> VM으로 이동
- 삭제버튼 눌렀을 때 알럿창의 action을 트리거로 VM에 보내서 데이터 삭제 로직 처리 구현

4. 개별 삭제로직도 cell에서 VM으로 이동
- 삭제한 후 삭제된 배열은 다시 한번 유저디폴트에 저장시킴